### PR TITLE
Implement generic typing to all shuffle functions

### DIFF
--- a/src/randomization.ts
+++ b/src/randomization.ts
@@ -43,9 +43,9 @@ function swapItems<T>(stimuli: Array<T>, i1: number, i2: number) {
 }
 
 // A constraint a key (string) that is allowed a number of times in a row
-type ConstraintMapping = { [key:string]: number};
+type ConstraintMapping = Record<string, number>;
 
-type StringToUnknownMapping = {[key:string] : unknown};
+type ItemType = Record<string, unknown>;
 
 /**
  * Checks whether an item may be appended to the randomized items
@@ -62,10 +62,10 @@ type StringToUnknownMapping = {[key:string] : unknown};
  * @return true if the item may be appended to randomized without violating
  *         the constraints false otherwise.
  */
-function allowPushItem (
-    randomized: Array<StringToUnknownMapping>,
+function allowPushItem<TItem extends ItemType> (
+    randomized: Array<TItem>,
     constraints: ConstraintMapping,
-    item: StringToUnknownMapping
+    item: TItem
 ) {
     for (const [key, max] of Object.entries(constraints)) {
         if (max < 1) {
@@ -125,11 +125,11 @@ function allowPushItem (
  *
  * @return {Array|null} An array if the order is fixed, null otherwise
  */
-function fixOrderForConstraints(
-    stimuli: Array<StringToUnknownMapping>,
-    constraints: ConstraintMapping): Array<StringToUnknownMapping> | null
+function fixOrderForConstraints<TItem extends ItemType>(
+    stimuli: Array<TItem>,
+    constraints: ConstraintMapping): Array<TItem> | null
 {
-    let output: Array<StringToUnknownMapping> = [];
+    let output: Array<TItem> = [];
     let copy = Array.from(stimuli)
     while(copy.length > 0) {
         let fitting = copy.findIndex((element) => {
@@ -159,12 +159,12 @@ function fixOrderForConstraints(
  * @returns {null|[]} The randomized order. Null if randomization
  * failed, in which case an error will have been logged to the console
  */
-function randomizePrivate(
-    original_stimuli: Array<StringToUnknownMapping>,
+function randomizePrivate<TItem extends ItemType>(
+    original_stimuli: Array<TItem>,
     constraints: ConstraintMapping,
     nth_try: number,
     max_tries: number
-) : Array<StringToUnknownMapping> | null {
+) : Array<TItem> | null {
     if (max_tries < 1) {
         throw new RangeError("max_tries is < 1");
     }
@@ -229,11 +229,11 @@ function randomizePrivate(
  * @returns {null|[]} The randomized order. Null if randomization
  * failed, in which case an error will have been logged to the console
  */
-function randomizeStimuli (
-    original_stimuli : Array<StringToUnknownMapping>,
+function randomizeStimuli<TItem extends ItemType> (
+    original_stimuli : Array<TItem>,
     max_same_type: number = 2,
     type_key:string = 'item_type'
-) : Array<StringToUnknownMapping> | null {
+) : Array<TItem> | null {
     let constraints = {[type_key] : max_same_type}; // ES6 dependency.
     return randomizePrivate(original_stimuli, constraints, 0, 10);
 }
@@ -254,11 +254,11 @@ function randomizeStimuli (
  * @returns {null|[]} The randomized order. Null if randomization
  * failed, in which case an error will have been logged to the console
  */
-function randomizeStimuliConstraints (
-    original_stimuli: Array<StringToUnknownMapping>,
+function randomizeStimuliConstraints<TItem extends ItemType> (
+    original_stimuli: Array<TItem>,
     constraints = {'item_type' : 2},
     max_tries = 10
-) : Array<StringToUnknownMapping> | null {
+) : Array<TItem> | null {
     return randomizePrivate(original_stimuli, constraints, 0, max_tries);
 }
 
@@ -299,11 +299,11 @@ function randomShuffle<T> (original_stimuli: Array<T>) : Array<T> {
  *
  * @return {null|Array.<Object>}
  */
-function randomShuffleConstraints (
-    original_stimuli: Array<StringToUnknownMapping>,
+function randomShuffleConstraints<TItem extends ItemType> (
+    original_stimuli: Array<TItem>,
     constraints: ConstraintMapping = {},
     max_tries : number = 10
-) : Array<StringToUnknownMapping> | null {
+) : Array<TItem> | null {
     if (max_tries < 1) {
         throw new RangeError("max_tries is < 1");
     }
@@ -329,8 +329,8 @@ function randomShuffleConstraints (
  * @param stimuli {Array.<object>}
  * @param constraints {Object}
  */
-function stimuliMeetConstraints (
-    stimuli: Array<StringToUnknownMapping>,
+function stimuliMeetConstraints<TItem extends ItemType> (
+    stimuli: Array<TItem>,
     constraints: ConstraintMapping
 ) : boolean {
     let valid = true;


### PR DESCRIPTION
This PR demonstrates how to implement constrained-generics to the randomization code, in response to this discussion:
https://github.com/UiL-OTS-labs/ils-online-utils/pull/1/files/4f36cccadd3c65195b981a3181420a671e6b0e7a#r2293475991